### PR TITLE
Add Expected_Size_Of_Five to Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,25 @@ strMap.Delete("foo")
 ### Benchmarks
 
 ```ocaml
+$ ./scripts/bench.sh
 + go test -bench=.
-goos: linux
+goos: windows
 goarch: amd64
 pkg: github.com/selfup/tinymap
-Benchmark_ByteMap_Get_Single_Lower_Bound-8              50000000                29.2 ns/op
-Benchmark_ByteMap_Get_Max_Size_Upper_Bound-8             3000000               584 ns/op
-Benchmark_IntMap_Get_Single_Lower_Bound-8               1000000000               2.62 ns/op
-Benchmark_IntMap_Get_Max_Size_Upper_Bound-8             30000000                49.8 ns/op
-Benchmark_IntStrMap_Get_Single_Lower_Bound-8            1000000000               2.89 ns/op
-Benchmark_IntStrMap_Get_Max_Size_Upper_Bound-8          30000000                55.5 ns/op
-Benchmark_StrMap_Get_Single_Lower_Bound-8               300000000                5.49 ns/op
-Benchmark_StrMap_Get_Max_Size_Upper_Bound-8              3000000               397 ns/op
+Benchmark_ByteMap_Get_Single_Lower_Bound-4              50000000                25.3 ns/op
+Benchmark_ByteMap_Get_Single_Expected_Bound-4           30000000                40.7 ns/op
+Benchmark_ByteMap_Get_Max_Size_Upper_Bound-4             3000000               520 ns/op
+Benchmark_IntMap_Get_Single_Lower_Bound-4               1000000000               2.51 ns/op
+Benchmark_IntMap_Get_Single_Expected_Bound-4            300000000                4.36 ns/op
+Benchmark_IntMap_Get_Max_Size_Upper_Bound-4             30000000                44.2 ns/op
+Benchmark_IntStrMap_Get_Single_Lower_Bound-4            1000000000               2.70 ns/op
+Benchmark_IntStrMap_Get_Single_Expected_Bound-4         300000000                4.46 ns/op
+Benchmark_IntStrMap_Get_Max_Size_Upper_Bound-4          30000000                50.3 ns/op
+Benchmark_StrMap_Get_Single_Lower_Bound-4               300000000                4.85 ns/op
+Benchmark_StrMap_Get_Single_Expected_Bound-4            300000000                5.42 ns/op
+Benchmark_StrMap_Get_Max_Size_Upper_Bound-4              5000000               382 ns/op
 PASS
-ok      github.com/selfup/tinymap       17.006s
+ok      github.com/selfup/tinymap       24.219s
 ```
 
 ### Details

--- a/tiny_byte_map_test.go
+++ b/tiny_byte_map_test.go
@@ -24,6 +24,20 @@ func Benchmark_ByteMap_Get_Single_Lower_Bound(b *testing.B) {
 	}
 }
 
+func Benchmark_ByteMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
+	byteMap := new(ByteMap)
+
+	byteMap.Set([]byte("0"), []byte("8996"))
+	byteMap.Set([]byte("0"), []byte("8997"))
+	byteMap.Set([]byte("0"), []byte("8998"))
+	byteMap.Set([]byte("0"), []byte("8999"))
+	byteMap.Set([]byte("42"), []byte("9000"))
+
+	for n := 0; n < b.N; n++ {
+		byteMap.Get([]byte("42"))
+	}
+}
+
 func Benchmark_ByteMap_Get_Max_Size_Upper_Bound(b *testing.B) {
 	byteMap := new(ByteMap)
 

--- a/tiny_int_map_test.go
+++ b/tiny_int_map_test.go
@@ -28,6 +28,20 @@ func Benchmark_IntMap_Get_Single_Lower_Bound(b *testing.B) {
 	}
 }
 
+func Benchmark_IntMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
+	intMap := new(IntMap)
+
+	intMap.Set(0, 8996)
+	intMap.Set(1, 8997)
+	intMap.Set(2, 8998)
+	intMap.Set(3, 8999)
+	intMap.Set(42, 9000)
+
+	for n := 0; n < b.N; n++ {
+		intMap.Get(42)
+	}
+}
+
 func Benchmark_IntMap_Get_Max_Size_Upper_Bound(b *testing.B) {
 	intMap := new(IntMap)
 

--- a/tiny_int_str_map_test.go
+++ b/tiny_int_str_map_test.go
@@ -28,6 +28,20 @@ func Benchmark_IntStrMap_Get_Single_Lower_Bound(b *testing.B) {
 	}
 }
 
+func Benchmark_IntStrMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
+	intStrMap := new(IntStrMap)
+
+	intStrMap.Set(0, "8996")
+	intStrMap.Set(1, "8997")
+	intStrMap.Set(2, "8998")
+	intStrMap.Set(3, "8999")
+	intStrMap.Set(42, "9000")
+
+	for n := 0; n < b.N; n++ {
+		intStrMap.Get(42)
+	}
+}
+
 func Benchmark_IntStrMap_Get_Max_Size_Upper_Bound(b *testing.B) {
 	intStrMap := new(IntStrMap)
 

--- a/tiny_str_map_test.go
+++ b/tiny_str_map_test.go
@@ -28,6 +28,20 @@ func Benchmark_StrMap_Get_Single_Lower_Bound(b *testing.B) {
 	}
 }
 
+func Benchmark_StrMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
+	strMap := new(StrMap)
+
+	strMap.Set("0", "8996")
+	strMap.Set("0", "8997")
+	strMap.Set("0", "8998")
+	strMap.Set("0", "8999")
+	strMap.Set("42", "9000")
+
+	for n := 0; n < b.N; n++ {
+		strMap.Get("42")
+	}
+}
+
 func Benchmark_StrMap_Get_Max_Size_Upper_Bound(b *testing.B) {
 	strMap := new(StrMap)
 


### PR DESCRIPTION
Typical Map size should be around 5.

Just adding benchmarks for the most common use case for all Map types.