### PR TITLE
Update Benchmark names - update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,18 @@ $ ./scripts/bench.sh
 goos: windows
 goarch: amd64
 pkg: github.com/selfup/tinymap
-Benchmark_ByteMap_Get_Single_Lower_Bound-4              50000000                25.3 ns/op
-Benchmark_ByteMap_Get_Single_Expected_Bound-4           30000000                40.7 ns/op
-Benchmark_ByteMap_Get_Max_Size_Upper_Bound-4             3000000               520 ns/op
-Benchmark_IntMap_Get_Single_Lower_Bound-4               1000000000               2.51 ns/op
-Benchmark_IntMap_Get_Single_Expected_Bound-4            300000000                4.36 ns/op
-Benchmark_IntMap_Get_Max_Size_Upper_Bound-4             30000000                44.2 ns/op
-Benchmark_IntStrMap_Get_Single_Lower_Bound-4            1000000000               2.70 ns/op
-Benchmark_IntStrMap_Get_Single_Expected_Bound-4         300000000                4.46 ns/op
-Benchmark_IntStrMap_Get_Max_Size_Upper_Bound-4          30000000                50.3 ns/op
-Benchmark_StrMap_Get_Single_Lower_Bound-4               300000000                4.85 ns/op
-Benchmark_StrMap_Get_Single_Expected_Bound-4            300000000                5.42 ns/op
-Benchmark_StrMap_Get_Max_Size_Upper_Bound-4              5000000               382 ns/op
+Benchmark_ByteMap_Get_Lower_Bound-4       50000000                25.3 ns/op
+Benchmark_ByteMap_Get_Expected_Bound-4    30000000                40.7 ns/op
+Benchmark_ByteMap_Get_Upper_Bound-4        3000000               520 ns/op
+Benchmark_IntMap_Get_Lower_Bound-4        1000000000               2.51 ns/op
+Benchmark_IntMap_Get_Expected_Bound-4     300000000                4.36 ns/op
+Benchmark_IntMap_Get_Upper_Bound-4        30000000                44.2 ns/op
+Benchmark_IntStrMap_Get_Lower_Bound-4     1000000000               2.70 ns/op
+Benchmark_IntStrMap_Get_Expected_Bound-4  300000000                4.46 ns/op
+Benchmark_IntStrMap_Get_Upper_Bound-4     30000000                50.3 ns/op
+Benchmark_StrMap_Get_Lower_Bound-4        300000000                4.85 ns/op
+Benchmark_StrMap_Get_Expected_Bound-4     300000000                5.42 ns/op
+Benchmark_StrMap_Get_Upper_Bound-4         5000000               382 ns/op
 PASS
 ok      github.com/selfup/tinymap       24.219s
 ```
@@ -55,6 +55,8 @@ ok      github.com/selfup/tinymap       24.219s
 
 1. Using an int as an index is fastest for lookups/comparisons.
 1. Using []byte as key is the slowest (makes sense)
+1. Lower Bound means the value being grabbed is the 1th element in a slice of 1 element.
+1. Expected Bound means the value is being grabbed at the 5th element in a sliace of 5 elements.
 1. Upper Bound means the value being grabbed is the 100th element in a slice of 100 elements.
 1. Under the hood TinyMap uses slices to store Tuples.
 1. I have not yet added a catch block to prevent the slice to grow, but this should be used for small data sotrage :pray:

--- a/tiny_byte_map_test.go
+++ b/tiny_byte_map_test.go
@@ -14,7 +14,7 @@ func Test_byteMap_Get(t *testing.T) {
 	}
 }
 
-func Benchmark_ByteMap_Get_Single_Lower_Bound(b *testing.B) {
+func Benchmark_ByteMap_Get_Lower_Bound(b *testing.B) {
 	byteMap := new(ByteMap)
 
 	byteMap.Set([]byte("1"), []byte("bar"))
@@ -24,7 +24,7 @@ func Benchmark_ByteMap_Get_Single_Lower_Bound(b *testing.B) {
 	}
 }
 
-func Benchmark_ByteMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
+func Benchmark_ByteMap_Get_Expected_Bound(b *testing.B) {
 	byteMap := new(ByteMap)
 
 	byteMap.Set([]byte("0"), []byte("8996"))
@@ -38,7 +38,7 @@ func Benchmark_ByteMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
 	}
 }
 
-func Benchmark_ByteMap_Get_Max_Size_Upper_Bound(b *testing.B) {
+func Benchmark_ByteMap_Get_Upper_Bound(b *testing.B) {
 	byteMap := new(ByteMap)
 
 	upperBound := 100

--- a/tiny_int_map_test.go
+++ b/tiny_int_map_test.go
@@ -18,7 +18,7 @@ func Test_IntMap_Get(t *testing.T) {
 	}
 }
 
-func Benchmark_IntMap_Get_Single_Lower_Bound(b *testing.B) {
+func Benchmark_IntMap_Get_Lower_Bound(b *testing.B) {
 	intMap := new(IntMap)
 
 	intMap.Set(42, 9000)
@@ -28,7 +28,7 @@ func Benchmark_IntMap_Get_Single_Lower_Bound(b *testing.B) {
 	}
 }
 
-func Benchmark_IntMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
+func Benchmark_IntMap_Get_Expected_Bound(b *testing.B) {
 	intMap := new(IntMap)
 
 	intMap.Set(0, 8996)
@@ -42,7 +42,7 @@ func Benchmark_IntMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
 	}
 }
 
-func Benchmark_IntMap_Get_Max_Size_Upper_Bound(b *testing.B) {
+func Benchmark_IntMap_Get_Upper_Bound(b *testing.B) {
 	intMap := new(IntMap)
 
 	upperBound := 100

--- a/tiny_int_str_map_test.go
+++ b/tiny_int_str_map_test.go
@@ -18,7 +18,7 @@ func Test_IntStrMap_Get(t *testing.T) {
 	}
 }
 
-func Benchmark_IntStrMap_Get_Single_Lower_Bound(b *testing.B) {
+func Benchmark_IntStrMap_Get_Lower_Bound(b *testing.B) {
 	intStrMap := new(IntStrMap)
 
 	intStrMap.Set(0, "_")
@@ -28,7 +28,7 @@ func Benchmark_IntStrMap_Get_Single_Lower_Bound(b *testing.B) {
 	}
 }
 
-func Benchmark_IntStrMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
+func Benchmark_IntStrMap_Get_Expected_Bound(b *testing.B) {
 	intStrMap := new(IntStrMap)
 
 	intStrMap.Set(0, "8996")
@@ -42,7 +42,7 @@ func Benchmark_IntStrMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
 	}
 }
 
-func Benchmark_IntStrMap_Get_Max_Size_Upper_Bound(b *testing.B) {
+func Benchmark_IntStrMap_Get_Upper_Bound(b *testing.B) {
 	intStrMap := new(IntStrMap)
 
 	upperBound := 100

--- a/tiny_str_map_test.go
+++ b/tiny_str_map_test.go
@@ -18,7 +18,7 @@ func Test_StrMap_Get(t *testing.T) {
 	}
 }
 
-func Benchmark_StrMap_Get_Single_Lower_Bound(b *testing.B) {
+func Benchmark_StrMap_Get_Lower_Bound(b *testing.B) {
 	strMap := new(StrMap)
 
 	strMap.Set("a", "_")
@@ -28,7 +28,7 @@ func Benchmark_StrMap_Get_Single_Lower_Bound(b *testing.B) {
 	}
 }
 
-func Benchmark_StrMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
+func Benchmark_StrMap_Get_Expected_Bound(b *testing.B) {
 	strMap := new(StrMap)
 
 	strMap.Set("0", "8996")
@@ -42,7 +42,7 @@ func Benchmark_StrMap_Get_Expected_Size_Of_Five_Upper_Bound(b *testing.B) {
 	}
 }
 
-func Benchmark_StrMap_Get_Max_Size_Upper_Bound(b *testing.B) {
+func Benchmark_StrMap_Get_Upper_Bound(b *testing.B) {
 	strMap := new(StrMap)
 
 	upperBound := 100


### PR DESCRIPTION
Less verbose Benchmark names.

Explain all benchmark bounds in README.