### PR TITLE
Add StrByteMap and Remove Benchmarks from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ language: go
 go:
   - '1.10.x'
   - '1.11.x'
-
-script: go test && scripts/bench.sh

--- a/README.md
+++ b/README.md
@@ -43,28 +43,33 @@ $ ./scripts/bench.sh
 goos: windows
 goarch: amd64
 pkg: github.com/selfup/tinymap
-Benchmark_ByteMap_Get_Lower_Bound-4             50000000                27.7 ns/op
-Benchmark_ByteMap_Get_Expected_Bound-4          50000000                34.5 ns/op
-Benchmark_ByteMap_Get_Upper_Bound-4              3000000               544 ns/op
-Benchmark_ByteMap_Set_Upper_Bound-4              5000000               287 ns/op
-Benchmark_ByteMap_Delete_Upper_Bound-4          100000000               11.3 ns/op
-Benchmark_IntMap_Get_Lower_Bound-4              1000000000               2.55 ns/op
-Benchmark_IntMap_Get_Expected_Bound-4           300000000                4.28 ns/op
-Benchmark_IntMap_Get_Upper_Bound-4              30000000                45.1 ns/op
-Benchmark_IntMap_Set_Upper_Bound-4              1000000000               2.83 ns/op
-Benchmark_IntMap_Delete_Upper_Bound-4           2000000000               1.85 ns/op
-Benchmark_IntStrMap_Get_Lower_Bound-4           1000000000               2.70 ns/op
-Benchmark_IntStrMap_Get_Expected_Bound-4        300000000                5.05 ns/op
-Benchmark_IntStrMap_Get_Upper_Bound-4           30000000                56.6 ns/op
-Benchmark_IntStrMap_Set_Upper_Bound-4           100000000               20.4 ns/op
-Benchmark_IntStrMap_Delete_Upper_Bound-4        2000000000               1.85 ns/op
-Benchmark_StrMap_Get_Lower_Bound-4              300000000                4.89 ns/op
-Benchmark_StrMap_Get_Expected_Bound-4           300000000                5.51 ns/op
-Benchmark_StrMap_Get_Upper_Bound-4               5000000               391 ns/op
-Benchmark_StrMap_Set_Upper_Bound-4              10000000               201 ns/op
-Benchmark_StrMap_Delete_Upper_Bound-4           200000000                6.37 ns/op
+Benchmark_ByteMap_Get_Lower_Bound-4             50000000                25.7 ns/op
+Benchmark_ByteMap_Get_Expected_Bound-4          50000000                29.3 ns/op
+Benchmark_ByteMap_Get_Upper_Bound-4              3000000               530 ns/op
+Benchmark_ByteMap_Set_Upper_Bound-4              5000000               302 ns/op
+Benchmark_ByteMap_Delete_Upper_Bound-4          100000000               11.7 ns/op
+Benchmark_IntMap_Get_Lower_Bound-4              1000000000               2.51 ns/op
+Benchmark_IntMap_Get_Expected_Bound-4           300000000                4.19 ns/op
+Benchmark_IntMap_Get_Upper_Bound-4              30000000                45.3 ns/op
+Benchmark_IntMap_Set_Upper_Bound-4              1000000000               2.84 ns/op
+Benchmark_IntMap_Delete_Upper_Bound-4           1000000000               2.09 ns/op
+Benchmark_IntStrMap_Get_Lower_Bound-4           1000000000               2.69 ns/op
+Benchmark_IntStrMap_Get_Expected_Bound-4        300000000                4.84 ns/op
+Benchmark_IntStrMap_Get_Upper_Bound-4           30000000                55.8 ns/op
+Benchmark_IntStrMap_Set_Upper_Bound-4           100000000               20.1 ns/op
+Benchmark_IntStrMap_Delete_Upper_Bound-4        1000000000               2.07 ns/op
+Benchmark_StrByteMap_Get_Lower_Bound-4          200000000                6.91 ns/op
+Benchmark_StrByteMap_Get_Expected_Bound-4       100000000               14.8 ns/op
+Benchmark_StrByteMap_Get_Upper_Bound-4           3000000               444 ns/op
+Benchmark_StrByteMap_Set_Upper_Bound-4           5000000               253 ns/op
+Benchmark_StrByteMap_Delete_Upper_Bound-4       200000000                6.45 ns/op
+Benchmark_StrMap_Get_Lower_Bound-4              300000000                4.86 ns/op
+Benchmark_StrMap_Get_Expected_Bound-4           300000000                4.95 ns/op
+Benchmark_StrMap_Get_Upper_Bound-4               5000000               325 ns/op
+Benchmark_StrMap_Set_Upper_Bound-4              10000000               196 ns/op
+Benchmark_StrMap_Delete_Upper_Bound-4           200000000                6.33 ns/op
 PASS
-ok      github.com/selfup/tinymap       44.851s
+ok      github.com/selfup/tinymap       49.282s
 ```
 
 ### Details

--- a/tiny_str_byte_map.go
+++ b/tiny_str_byte_map.go
@@ -1,0 +1,85 @@
+package tinymap
+
+import (
+	"errors"
+	"fmt"
+)
+
+// StrByteTuple is a basic struct
+//
+//  StrByteTuple{Key: "foo", Val: "bar"}
+type StrByteTuple struct {
+	Key string
+	Val []byte
+}
+
+// StrByteMap stores StrByteTuples
+//
+// It behaves like a HashMap!
+//
+//  strByteMap := new(StrByteMap)
+//  strByteMap.Set("foo", []byte("bar"))
+//  val, err := strByteMap.Get("foo")
+//
+//  if err != nil {
+//    log.Fatal(err)
+//  }
+//
+//  fmt.Print(val)
+//
+//  strByteMap.Delete(42)
+type StrByteMap struct {
+	// Data is public but use carefully :)
+	Data []StrByteTuple
+}
+
+// Get fetches Tuples by Key and returns their Val
+func (t StrByteMap) Get(key string) ([]byte, error) {
+	for _, StrByteTuple := range t.Data {
+		if StrByteTuple.Key == key {
+			return StrByteTuple.Val, nil
+		}
+	}
+
+	var errVal []byte
+	errMsg := fmt.Sprintf("No such key (%v) - []byte default returned", key)
+	err := errors.New(errMsg)
+
+	return errVal, err
+}
+
+// Set will update or add Tuples.
+// If StrByteTuple.Key already exists, only the StrByteTuple.Val is updated.
+// Otherwise a new StrByteTuple is inserted into the Data slice.
+func (t *StrByteMap) Set(key string, val []byte) {
+	for i, StrByteTuple := range t.Data {
+		if StrByteTuple.Key == key {
+			StrByteTuple.Val = val
+
+			t.Data[i] = StrByteTuple
+
+			return
+		}
+	}
+
+	StrByteTuple := StrByteTuple{Key: key, Val: val}
+
+	t.Data = append(t.Data, StrByteTuple)
+}
+
+// Delete removes Tuples.
+// Returns true if deleted.
+// Returns false if the key was not found.
+func (t *StrByteMap) Delete(key string) bool {
+	for i, StrByteTuple := range t.Data {
+		if StrByteTuple.Key == key {
+			t.Data[i] = t.Data[len(t.Data)-1]
+			t.Data[len(t.Data)-1] = StrByteTuple
+			t.Data = t.Data[:len(t.Data)-1]
+
+			return true
+		}
+	}
+
+	return false
+}

--- a/tiny_str_byte_map_test.go
+++ b/tiny_str_byte_map_test.go
@@ -1,0 +1,118 @@
+package tinymap
+
+import (
+	"bytes"
+	"testing"
+)
+
+func Test_StrByteMap_Get(t *testing.T) {
+	strByteMap := new(StrByteMap)
+
+	var defaultByte []byte
+	result, err := strByteMap.Get("foo")
+
+	if !bytes.Equal(result, defaultByte) {
+		t.Errorf("failed to return []byte default")
+	}
+
+	if err == nil {
+		t.Errorf("Get without known key should have failed")
+	}
+}
+
+func Test_StrByteMap_Set(t *testing.T) {
+	strByteMap := new(StrByteMap)
+
+	key := []byte("bar")
+
+	strByteMap.Set("foo", key)
+
+	result, _ := strByteMap.Get("foo")
+
+	if !bytes.Equal(result, key) {
+		t.Errorf("failed to return correct Val from StrByteTuple")
+	}
+}
+
+func Benchmark_StrByteMap_Get_Lower_Bound(b *testing.B) {
+	strByteMap := new(StrByteMap)
+
+	key := []byte("_")
+
+	strByteMap.Set("a", key)
+
+	for n := 0; n < b.N; n++ {
+		strByteMap.Get("a")
+	}
+}
+
+func Benchmark_StrByteMap_Get_Expected_Bound(b *testing.B) {
+	strByteMap := new(StrByteMap)
+
+	zero := []byte("8996")
+	one := []byte("8997")
+	two := []byte("8998")
+	three := []byte("8999")
+	fortyTwo := []byte("9000")
+
+	strByteMap.Set("0", zero)
+	strByteMap.Set("1", one)
+	strByteMap.Set("2", two)
+	strByteMap.Set("3", three)
+	strByteMap.Set("42", fortyTwo)
+
+	for n := 0; n < b.N; n++ {
+		strByteMap.Get("42")
+	}
+}
+
+func Benchmark_StrByteMap_Get_Upper_Bound(b *testing.B) {
+	strByteMap := new(StrByteMap)
+
+	upperBound := 100
+	upperBoundStr := string(upperBound)
+
+	for i := 0; i < upperBound; i++ {
+		strByteMap.Set(string(i), []byte(string(i)))
+	}
+
+	strByteMap.Set(upperBoundStr, []byte(string(upperBound)))
+
+	for n := 0; n < b.N; n++ {
+		strByteMap.Get(upperBoundStr)
+	}
+}
+
+func Benchmark_StrByteMap_Set_Upper_Bound(b *testing.B) {
+	strByteMap := new(StrByteMap)
+
+	for i := 0; i < b.N; i++ {
+		val := []byte(string(i))
+
+		if i < 100 {
+			strByteMap.Set(string(i), val)
+		} else {
+			strByteMap.Set("1", val)
+		}
+	}
+}
+
+func Benchmark_StrByteMap_Delete_Upper_Bound(b *testing.B) {
+	strByteMap := new(StrByteMap)
+
+	for i := 0; i < 100; i++ {
+		val := string(i)
+
+		strByteMap.Set(val, []byte(val))
+	}
+
+	for i := 0; i < b.N; i++ {
+		val := string(i)
+
+		if i < 100 {
+			strByteMap.Delete(val)
+		} else {
+			strByteMap.Delete("1")
+		}
+	}
+}


### PR DESCRIPTION
StrByteMap stores StrByteTuples

It behaves like a HashMap!

```go
 strByteMap := new(StrByteMap)
 strByteMap.Set("foo", []byte("bar"))
 val, err := strByteMap.Get("foo")

 if err != nil {
   log.Fatal(err)
 }

 fmt.Print(val)

 strByteMap.Delete(42)
 ```