### PR TITLE
fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ if err != nil {
 
 fmt.Print(val)
 
-strMap.Delete(42)
+strMap.Delete("foo")
 ```
 
 ### Benchmarks

--- a/tiny_str_byte_map.go
+++ b/tiny_str_byte_map.go
@@ -27,7 +27,7 @@ type StrByteTuple struct {
 //
 //  fmt.Print(val)
 //
-//  strByteMap.Delete(42)
+//  strByteMap.Delete("foo")
 type StrByteMap struct {
 	// Data is public but use carefully :)
 	Data []StrByteTuple

--- a/tiny_str_map.go
+++ b/tiny_str_map.go
@@ -27,7 +27,7 @@ type StrTuple struct {
 //
 //  fmt.Print(val)
 //
-//  strMap.Delete(42)
+//  strMap.Delete("foo")
 type StrMap struct {
 	// Data is public but use carefully :)
 	Data []StrTuple


### PR DESCRIPTION
3 examples had `42` for the value trying to be deleted when they were supposed to be a  "foo" string instead